### PR TITLE
Bump to Bootstrap v4.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-This is a [Hugo Components](https://gohugo.io/hugo-modules/) that packages the [Bootstrap v4](https://getbootstrap.com/docs/4.4/getting-started/introduction/) SCSS source ready to be used in Hugo.
+This is a [Hugo module](https://gohugo.io/hugo-modules/) that packages the [Bootstrap v4](https://getbootstrap.com/docs/4.6/getting-started/introduction/) SCSS source ready to be used in Hugo.
 
-You need the Hugo extended version and Go to use this component.
+You need the Hugo extended version and [Go](https://golang.org/dl/) to use this component.
 
 ## Use
 

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/gohugoio/hugo-mod-bootstrap-scss-v4
 
 go 1.13
 
-require github.com/twbs/bootstrap v4.5.2+incompatible // indirect
+require github.com/twbs/bootstrap v4.6.0+incompatible // indirect

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/gohugoio/hugo-mod-bootstrap-scss-v4
 
 go 1.13
 
-require github.com/twbs/bootstrap v4.6.0+incompatible // indirect
+require github.com/twbs/bootstrap v4.6.1+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,2 @@
-github.com/twbs/bootstrap v4.4.1+incompatible h1:AueNOcQyhFaWJDynY+tJaK1QR+9Dx2CpqW+EoTBUznk=
-github.com/twbs/bootstrap v4.4.1+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=
-github.com/twbs/bootstrap v4.5.2+incompatible h1:QR6UOtm1+LCDK53CzEp8U0NPIYeRUktVgNhq0gaAGP0=
-github.com/twbs/bootstrap v4.5.2+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=
+github.com/twbs/bootstrap v4.6.0+incompatible h1:gHX/lyS+3sUtHS6AKI365MfWukJ9N/Mltrc0lfdXYfs=
+github.com/twbs/bootstrap v4.6.0+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,8 @@
+github.com/twbs/bootstrap v4.4.1+incompatible h1:AueNOcQyhFaWJDynY+tJaK1QR+9Dx2CpqW+EoTBUznk=
+github.com/twbs/bootstrap v4.4.1+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=
+github.com/twbs/bootstrap v4.5.2+incompatible h1:QR6UOtm1+LCDK53CzEp8U0NPIYeRUktVgNhq0gaAGP0=
+github.com/twbs/bootstrap v4.5.2+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=
 github.com/twbs/bootstrap v4.6.0+incompatible h1:gHX/lyS+3sUtHS6AKI365MfWukJ9N/Mltrc0lfdXYfs=
 github.com/twbs/bootstrap v4.6.0+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=
+github.com/twbs/bootstrap v4.6.1+incompatible h1:75PsBfPU1SS65ag0Z3Cq6JNXVAfUNfB0oCLHh9k9Fu8=
+github.com/twbs/bootstrap v4.6.1+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=


### PR DESCRIPTION
This PR
- bumps bootstrap to latest version 4.6.1
- corrects minor issues in README.md

From `README.md`:

`This repository will be versioned following the minor and patch versions in the v4 series of Bootstrap.`

Can you please:

- add tag v4.6.0 to first commit `43bcc9b`
- add tag v4.6.1 to second commit `02f71b4`
 
Thanks.